### PR TITLE
Use modern chown command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ git clone https://github.com/poddmo/ufw-blocklist.git
 cd ufw-blocklist
 sudo cp after.init /etc/ufw/after.init
 sudo cp ufw-blocklist-ipsum /etc/cron.daily/ufw-blocklist-ipsum
-sudo chown root.root /etc/ufw/after.init /etc/cron.daily/ufw-blocklist-ipsum
+sudo chown root:root /etc/ufw/after.init /etc/cron.daily/ufw-blocklist-ipsum
 sudo chmod 750 /etc/ufw/after.init /etc/cron.daily/ufw-blocklist-ipsum
 ```
 


### PR DESCRIPTION
Hello,

On my server running on Debian 12 (Bookworm), the chown syntax that uses `root.root` is not recognized. This seems to be an [old syntax that is not supported by some modern OSes](https://serverfault.com/questions/194295/using-dot-as-delimiter-to-specify-group-in-chown).

This PR just replaces `root.root` with the more modern syntax `root:root` in the README file.

Thank you for this usefull tool.