### PR TITLE
Allow CIDR style IPs

### DIFF
--- a/after.init
+++ b/after.init
@@ -114,7 +114,7 @@ start)
     # start this in a subshell and then disown the job so we return quickly.
     (
 	# only include ip addresses from the start of the line
-	egrep -o "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}" "$seedlist" |\
+	egrep -o "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(|/[0-9]{1,2})" "$seedlist" |\
 	    while read ip
         	do
     			$IPSET_EXE add "$ipsetname" "$ip"

--- a/ufw-blocklist-ipsum
+++ b/ufw-blocklist-ipsum
@@ -44,7 +44,7 @@ fi
 
 ## Read the list into an array, filtering for only ip addresses from the start of a line
 declare -a scrublist
-readarray -t scrublist < <(echo "$rawlist" | egrep -o "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}")
+readarray -t scrublist < <(echo "$rawlist" | egrep -o "^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(|/[0-9]{1,2})")
 
 ## Validate the list length
 scrublistlen="${#scrublist[@]}"


### PR DESCRIPTION
Since we are now validating IPs, we should make sure to still allow CIDR notation with ranges, as ufw can handle those.

Usecase: I use an allowlist which uses those ranges, and it should not have any unforeseen consequences. 